### PR TITLE
Fix determining first sector of track

### DIFF
--- a/imagedisk.py
+++ b/imagedisk.py
@@ -184,9 +184,9 @@ class ImageDisk:
 
         # write header
         dt = self.timestamp.strftime('%d/%m/%Y %H:%M:%S')
-        f.write(bytes('IMD 1.18 %s\r' % dt, encoding='ascii'))
+        f.write(bytes('IMD 1.18 %s\r\n' % dt, encoding='ascii'))
         if self.comment is not None:
-            f.write(bytes(self.comment + '\r', 'utf-8'))
+            f.write(bytes(self.comment + '\r\n', 'utf-8'))
         f.write(bytes([0x1a]))
 
         tl = sorted(self.tracks.keys())

--- a/kfsf.py
+++ b/kfsf.py
@@ -137,7 +137,9 @@ class KyroFluxStream(FluxImageBlock):
         self.flux_sample_counter += self.overflow + offset
         self.overflow = 0
 
-        self.flux_trans_abs.append(self.flux_sample_counter)
+        # Discard all flux transitions before index pulse
+        if self.index_abs and self.flux_sample_counter > self.index_abs[0]:
+            self.flux_trans_abs.append(self.flux_sample_counter)
 
         if self.stream_offset in self.pending_index_blocks:
             index = self.pending_index_blocks[self.stream_offset]


### PR DESCRIPTION
The code can still get the first sector wrong if the disk has read errors. Without read errors it now matches [https://github.com/ogdenpm/disktools](https://github.com/ogdenpm/disktools)