### PR TITLE
Fix MFM bugs, add number of sectors as a CLI parameter

### DIFF
--- a/fluximage.py
+++ b/fluximage.py
@@ -109,7 +109,18 @@ class FluxImageBlock:
             if len(s) == 0 and c != 0:
                 s = '.'
             print("%3.2f: %5d %s" % (i * bucket_size / (self.frequency / 1.0e6), c, s))
-    
+
+
+class FluxImageDummyBlock(FluxImageBlock):
+    def __init__(self, frequency, head, cylinder):
+        self.frequency = frequency
+        self.cylinder = cylinder
+        self.head = head
+        self.sector = 1
+        self.index_pos = [0]
+        self.flux_trans_abs = [0]
+        self.flux_trans_rel = [0]
+
 
 class FluxImage:
     def __init__(self, fluximagefile, debug = False):

--- a/fluxtoimd.py
+++ b/fluxtoimd.py
@@ -267,7 +267,7 @@ for track_num in range(args.tracks):
         if args.imagedisk_image is not None:
             for sector_num in range(first_sector, first_sector + sectors_per_track):
                 if sector_num not in track:
-                    print('*** BAD nodata: track %02d sector %02d\n' % (track_num, sector_num))
+                    print('*** BAD nodata: head %01d track %02d sector %02d\n' % (side_num, track_num, sector_num))
             for sector_num in track:
                 deleted = track[sector_num][0]
                 data = track[sector_num][1]
@@ -275,17 +275,20 @@ for track_num in range(args.tracks):
                 if data is not None:
                     #print('writing track %02d sector %02d\n' % (track_num, sector_num))
                     if bad:
-                        print('*** BAD: track %02d sector %02d\n' % (track_num, sector_num))
-                    imd.write_sector(args.modulation.imagedisk_mode,
-                                     track_num,  # cylinder
-                                     side_num,   # head
-                                     sector_num,
-                                     bytes(data),
-                                     deleted = deleted,
-                                     bad = bad)
+                        print('*** BAD: head %01d track %02d sector %02d\n' % (side_num, track_num, sector_num))
+                    try:
+                        imd.write_sector(args.modulation.imagedisk_mode,
+                                         track_num,  # cylinder
+                                         side_num,   # head
+                                         sector_num,
+                                         bytes(data),
+                                         deleted = deleted,
+                                         bad = bad)
+                    except ImageDisk.InvalidSectorSizeException as e:
+                        print('*** ERROR: %s. Could not write, skipping' % e)
                 else:
                     # If sector not found then no data written to file for sector
-                    print('*** BAD nodata: track %02d sector %02d\n' % (track_num, sector_num))
+                    print('*** BAD nodata: head %01d track %02d sector %02d\n' % (side_num, track_num, sector_num))
                     pass
 
 if args.imagedisk_image is not None:

--- a/fluxtoimd.py
+++ b/fluxtoimd.py
@@ -19,6 +19,7 @@ import argparse
 import re
 from collections import OrderedDict
 
+from scp import SCP      # SuperCardPro image format
 from dfi import DFI      # DiscFerret image format
 from kfsf import KFSF    # KryoFlux stream format
 from adpll import ADPLL
@@ -167,7 +168,7 @@ parser.add_argument('flux_image', type=argparse.FileType('rb'))
 parser.add_argument('imagedisk_image', type=argparse.FileType('wb'))
 parser.add_argument('-C', '--comment', action = 'store')
 
-parser.add_argument('-F', '--flux_format', choices=['dfi', 'ksf'], default = 'dfi')
+parser.add_argument('-F', '--flux_format', choices=['dfi', 'ksf', 'scp'], default = 'dfi')
 
 parser_modulation = parser.add_mutually_exclusive_group(required = False)
 parser_modulation.add_argument('--fm',   action = 'store_const', const = FM,   dest = 'modulation', help = 'FM modulation, IBM 3740 single density')
@@ -190,6 +191,8 @@ if args.flux_format == 'dfi':
     flux_image = DFI(args.flux_image, frequency = args.frequency * 1.0e6)
 elif args.flux_format == 'ksf':
     flux_image = KFSF(args.flux_image)
+elif args.flux_format == 'scp':
+    flux_image = SCP(args.flux_image)
 
 if args.modulation == HPM2FM and args.index:
     print("index mark option ignored, as HP M2FM doesn't use index marks")

--- a/fluxtoimd.py
+++ b/fluxtoimd.py
@@ -91,7 +91,7 @@ def dump_track(modulation,
         if (modulation.crc_includes_address_mark):
             crc.comp(id_field)
         else:
-            crc.comp(id_field[1:])
+            crc.comp(id_field[modulation.address_mark_length:])
         if crc.get() != 0:
             print("*** bad ID field CRC %04x" % crc.get())
             hex_dump(id_field)
@@ -105,8 +105,12 @@ def dump_track(modulation,
                 id_sector -= 0x80
                 id_head = 1
             id_size = 1
+        elif modulation.id_field_length == 4:
+            id_track, id_head, id_sector, id_size = id_field[modulation.address_mark_length:modulation.address_mark_length+4]
         else:
-            id_track, id_head, id_sector, id_size = id_field[1:5]
+            print("*** ID field with unknown format")
+            hex_dump(id_field)
+            continue
         #print('head %d track %02d sector %02d' % (id_head, id_track, id_sector))
         if id_head != side:
             print("*** ID field with wrong head number")
@@ -127,12 +131,12 @@ def dump_track(modulation,
         sectors[id_sector] = [False, None, True]
 
         deleted = False
-        data_pos = bits.find(modulation.data_address_mark, id_pos + len(modulation.id_address_mark) + 16 * (modulation.id_field_length + 2))
+        data_pos = bits.find(modulation.data_address_mark, id_pos + len(modulation.data_address_mark) + 16 * (modulation.id_field_length + 2))
         if (modulation.id_to_data_half_bits - 50) <= (data_pos - id_pos) <= (modulation.id_to_data_half_bits + 50):
             #print('  data address mark at channel bit offset %d' % (data_pos - id_pos))
             pass
         elif hasattr(modulation, 'deleted_data_address_mark'):
-            data_pos = bits.find(modulation.deleted_data_address_mark, id_pos + len(modulation.id_address_mark) + 96)
+            data_pos = bits.find(modulation.deleted_data_address_mark, id_pos + len(modulation.data_address_mark) + 96)
             if (modulation.id_to_data_half_bits - 50) <= (data_pos - id_pos) <= (modulation.id_to_data_half_bits + 50):
                 #print('  deleted data address mark at channel bit offset %d' % (deleted_data_pos - id_pos))
                 deleted = True
@@ -145,19 +149,19 @@ def dump_track(modulation,
             hex_dump(id_field)
             continue
 
-        data_field = modulation.decode(bits[data_pos: data_pos + len(modulation.id_address_mark) + (bc + 2) * 16])
+        data_field = modulation.decode(bits[data_pos: data_pos + len(modulation.data_address_mark) + (bc + 2) * 16])
         crc.reset()
         if (modulation.crc_includes_address_mark):
             crc.comp(data_field)
         else:
-            crc.comp(data_field[1:])
+            crc.comp(data_field[modulation.address_mark_length:])
         if crc.get() == 0:
-            sectors [id_sector] = (deleted, data_field[1:bc+1], False)
+            sectors [id_sector] = (deleted, data_field[modulation.address_mark_length:bc+modulation.address_mark_length], False)
         else:
             print("*** bad data field CRC track %d side %d sector %d" % (track, side, id_sector))
             # Only update sector if bad to prevent overwriting good with bad
             if sectors[id_sector][2]:
-                sectors [id_sector] = (deleted, data_field[1:bc+1], True)
+                sectors [id_sector] = (deleted, data_field[modulation.address_mark_length:bc+modulation.address_mark_length], True)
 
     return sectors
 
@@ -180,6 +184,7 @@ parser.set_defaults(modulation = FM)
 
 parser.add_argument('-s', '--sides',      type=int, default = 1, choices = [1, 2], help='number of sides')
 parser.add_argument('-t', '--tracks',     type=int, default = 77, help='number of tracks')
+parser.add_argument('-n', '--sectors',     type=int, default = -1, help='number of sectors')
 
 parser.add_argument('-f', '--frequency',  type=float, help = 'sample rate in MHz', default=25.0)
 parser.add_argument('-b', '--bit-rate',   type=float, help = 'bit rate in Kbps')
@@ -226,7 +231,11 @@ hbc = 1/hbr                  # half-bit cycle in s
 
 
 first_sector = args.modulation.default_first_sector
-sectors_per_track = args.modulation.default_sectors_per_track
+
+if args.sectors > 0:
+    sectors_per_track = args.sectors
+else:
+    sectors_per_track = args.modulation.default_sectors_per_track
 
 bad_sectors = 0
 data_sectors = 0

--- a/imagedisk.py
+++ b/imagedisk.py
@@ -64,9 +64,9 @@ class ImageDisk:
         if track_coord not in self.tracks:
             self.tracks[track_coord] = OrderedDict()
         if (not replace_ok) and (sector in self.tracks[track_coord]):
-            raise DuplicateSectorException('duplicate sector, cyl=%d, head=%d, sector=%d' % (cylinder, head, sector))
+            raise ImageDisk.DuplicateSectorException('duplicate sector, cyl=%d, head=%d, sector=%d' % (cylinder, head, sector))
         if len(data) not in self.__sector_size_map:
-            raise InvalidSectorSizeException('invalid sector size, cyl=%d, head=%d, sector=%d, size=%d' % (cylinder, head, sector, len(data)))
+            raise ImageDisk.InvalidSectorSizeException('invalid sector size, cyl=%d, head=%d, sector=%d, size=%d' % (cylinder, head, sector, len(data)))
         self.tracks[track_coord][sector] = ImageDisk.Sector(mode, deleted, self.__sector_size_map[len(data)], data, bad)
 
 
@@ -108,7 +108,7 @@ class ImageDisk:
             # XXX read header
             s = f.read(4)
             if s != b'IMD ':
-                raise NotImageDiskFileException()
+                raise ImageDisk.NotImageDiskFileException()
             c = 0
             while c != bytes([0x1a]):
                 c = f.read(1)
@@ -129,7 +129,7 @@ class ImageDisk:
         try:
             data = self.tracks[(cylinder, head)][sector].data
         except KeyError:
-            raise NonexistentSectorException()
+            raise ImageDisk.NonexistentSectorException()
         return data
 
     def __write_track(self, f, tc):
@@ -142,7 +142,7 @@ class ImageDisk:
             if mode is None:
                 mode = sector.mode
             elif mode != sector.mode:
-                raise MixedModeTrackException('mixed modes, cyl=%d, head=%d' % tc)
+                raise ImageDisk.MixedModeTrackException('mixed modes, cyl=%d, head=%d' % tc)
             if sector_size_code is None:
                 sector_size_code = sector.size_code
             elif sector_size_code != sector.size_code:

--- a/modulation.py
+++ b/modulation.py
@@ -25,9 +25,9 @@ class Modulation:
     def decode(cls, channel_bits):
         bytes = []
         bits = ''
-        for i in range(0, len(channel_bits), 2):
-            clock = int(channel_bits[i])
-            data = int(channel_bits[i+1])
+        for i in range(1, len(channel_bits), 2):
+            clock = int(channel_bits[i-1])
+            data = int(channel_bits[i])
             if cls.lsb_first:
                 bits = '01'[data] + bits
             else:

--- a/modulation.py
+++ b/modulation.py
@@ -55,6 +55,7 @@ class FM(Modulation):
     id_field_length = 4
     crc_init = 0xffff
     crc_includes_address_mark = True
+    address_mark_length = 1
 
     id_to_data_half_bits = 400
 
@@ -92,6 +93,9 @@ class MFM(Modulation):
     id_field_length = 4
     crc_init = 0xffff
     crc_includes_address_mark = True
+    address_mark_length = 4
+
+    id_to_data_half_bits = 700
 
     # Would prefer to use a more general @staticmethod encode, but then can't call in
     # class initialization
@@ -99,14 +103,15 @@ class MFM(Modulation):
     def encode_mark(data1, missing_clock1, data2):
         prev_d = 0
         bits = ''
-        for i in range(7, -1, -1):
-            d = (data1  >> i) & 1
-            if (prev_d == 0) and (d == 0) and (i != (6 - missing_clock1)):
-                c = 1
-            else:
-                c = 0
-            bits += ('%d%d' % (c, d))
-            prev_d = d
+        for _ in range(3):
+            for i in range(7, -1, -1):
+                d = (data1  >> i) & 1
+                if (prev_d == 0) and (d == 0) and (i != (6 - missing_clock1)):
+                    c = 1
+                else:
+                    c = 0
+                bits += ('%d%d' % (c, d))
+                prev_d = d
         for i in range(7, -1, -1):
             d = (data2  >> i) & 1
             if prev_d == 0 and d == 0:
@@ -149,6 +154,7 @@ class IntelM2FM(Modulation):
     id_field_length = 4
     crc_init = 0x0000
     crc_includes_address_mark = True
+    address_mark_length = 1
 
     id_to_data_half_bits = 600
 
@@ -199,6 +205,7 @@ class HPM2FM(Modulation):
     id_field_length = 2
     crc_init = 0xffff
     crc_includes_address_mark = False
+    address_mark_length = 1
 
     id_to_data_half_bits = 480
 

--- a/scp.py
+++ b/scp.py
@@ -1,0 +1,99 @@
+import struct
+
+from fluximage import CHS, FluxImage, FluxImageBlock
+
+class SCPBlock(FluxImageBlock):
+
+    def __init__(self, fluximagefile, frequency, head, cylinder, revolutions, debug = False):
+        super().__init__(fluximagefile, debug)
+        self.frequency = frequency
+        self.head = head
+        self.cylinder = cylinder
+        self.sector = 1
+
+        if self.debug:
+            print('head %d, cylinder %d' % (self.head, self.cylinder))
+
+        magic = self.fluximagefile.read(3)
+        if magic != b'TRK':
+            raise Exception('bad magic ' + str(magic))
+        trk_no = self.read_u8()
+        trk_duration = []
+        trk_len = []
+        trk_ptr = []
+
+        for _ in range(revolutions):
+            trk_duration.append(self.read_u32_le())
+            trk_len.append(self.read_u32_le())
+            trk_ptr.append(self.read_u32_le())
+
+        self.index_pos = []
+        self.flux_trans_abs = []
+        time_inc = 0
+        for r in range(revolutions):
+            if self.debug:
+                print('revolution %d, length %d' % (r+1, trk_len[r]))
+            for _ in range(trk_len[r]):
+                time_inc += self.read_u16_be()
+                self.flux_trans_abs.append(time_inc)
+            if trk_len[r] > 0:
+                self.index_pos.append(time_inc)
+                self.end_time = time_inc
+
+
+
+class SCP(FluxImage):
+
+    def read_u8(self):
+        return struct.unpack('<B', self.fluximagefile.read(1))[0]
+
+    def read_s8(self):
+        return struct.unpack('<b', self.fluximagefile.read(1))[0]
+
+    def read_u32_le(self):
+        return struct.unpack('<I', self.fluximagefile.read(4))[0]
+
+    def __init__(self, fluximagefile, debug = False):
+        super().__init__(fluximagefile, debug)
+
+        magic = self.fluximagefile.read(3)
+        if magic != b'SCP':
+            raise Exception('bad magic ' + str(magic))
+
+        version = self.read_u8()
+        subversion = version%16
+        version = version/16
+        type = self.read_u8()
+        revolutions = self.read_u8()
+        starttrack = self.read_u8()
+        endtrack = self.read_u8()
+        flags = self.read_u8()
+        width = self.read_u8()
+        head_cfg = self.read_s8()
+        main_head = (0, 0, 1)[head_cfg]
+        heads = (2, 1, 1)[head_cfg]
+        self.frequency = 40e6/(self.read_u8()+1) 
+        checksum = self.read_u32_le()
+
+        if self.debug:
+            print('freq %f, %i head(s), track %i -> %i, %i revolutions' % (self.frequency, heads, starttrack, endtrack, revolutions))
+
+        track_ptrs = []
+        for track in range(starttrack, endtrack+1):
+            track_ptrs.append(self.read_u32_le())
+            if heads == 1:
+                track_ptrs.append(self.read_u32_le())
+
+        self.blocks = {}
+        i = 0
+        for track in range(starttrack, endtrack+1):
+            if debug:
+                print('Loading track ' + str(track))
+            while track_ptrs[i] == 0:
+                i += 1
+            fluximagefile.seek(track_ptrs[i])
+            block = SCPBlock(fluximagefile, self.frequency, main_head + track%heads, int(track/heads), revolutions, debug = self.debug)
+            if debug:
+                print('CHS ' + str(block.chs()))
+            self.blocks[block.chs()] = block
+            i += 1

--- a/scp.py
+++ b/scp.py
@@ -1,6 +1,6 @@
 import struct
 
-from fluximage import CHS, FluxImage, FluxImageBlock
+from fluximage import CHS, FluxImage, FluxImageBlock, FluxImageDummyBlock
 
 class SCPBlock(FluxImageBlock):
 
@@ -72,28 +72,29 @@ class SCP(FluxImage):
         head_cfg = self.read_s8()
         main_head = (0, 0, 1)[head_cfg]
         heads = (2, 1, 1)[head_cfg]
-        self.frequency = 40e6/(self.read_u8()+1) 
+        self.frequency = 40e6/(self.read_u8()+1)
         checksum = self.read_u32_le()
 
         if self.debug:
             print('freq %f, %i head(s), track %i -> %i, %i revolutions' % (self.frequency, heads, starttrack, endtrack, revolutions))
 
         track_ptrs = []
+        if heads == 1 and main_head == 1:
+            self.read_u32_le()
         for track in range(starttrack, endtrack+1):
             track_ptrs.append(self.read_u32_le())
             if heads == 1:
-                track_ptrs.append(self.read_u32_le())
+                self.read_u32_le()
 
         self.blocks = {}
-        i = 0
         for track in range(starttrack, endtrack+1):
             if debug:
                 print('Loading track ' + str(track))
-            while track_ptrs[i] == 0:
-                i += 1
-            fluximagefile.seek(track_ptrs[i])
-            block = SCPBlock(fluximagefile, self.frequency, main_head + track%heads, int(track/heads), revolutions, debug = self.debug)
+            if track_ptrs[track] != 0:
+                fluximagefile.seek(track_ptrs[track])
+                block = SCPBlock(fluximagefile, self.frequency, main_head + track%heads, int(track/heads), revolutions, debug = self.debug)
+            else:
+                block = FluxImageDummyBlock(self.frequency, main_head + track%heads, int(track/heads))
             if debug:
                 print('CHS ' + str(block.chs()))
             self.blocks[block.chs()] = block
-            i += 1


### PR DESCRIPTION
MFM modulation was missing variables, and was leaving out needed address-marks in the CRC calculation. These issues should be fixed here.

Number of expected sectors can now also be set using a CLI parameter, enabling the tool to be used with more common formats (for example images of IBM-PC formatted floppy disks).